### PR TITLE
Readme cmd cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center">
   <img src="https://images.squarespace-cdn.com/content/637dc346cd653e686a50c1f5/d2ed870c-7705-44fb-906a-4fe28b64f1f4/smockit-logo.png?content-type=image%2Fpng" alt="Smockit Logo" />
 </p>
@@ -15,23 +14,23 @@ Smock-it is a powerful CLI plugin, a tool for generating mock data for Salesforc
 
 Want to get started with Smock-it?  [**Quick Start Guide**](https://github.com/concretios/smock-it/wiki/Quick-Start-Guide).
 
-## What\`s New in v3?
+## What`s New in v3?
 
 Smock-it v3 brings smarter, faster test data generation for Salesforce, with:
 
-### 1\. Native Data Library
+### 1. Native Data Library
 
 Smock-it has eliminated its dependency on mockaroo and now comes with its own data library. This allows it to generate 100% unique data up to 300K records for Salesforce standard duplicate rules.
 
-### 2\. Realistic Address Mapping
+### 2. Realistic Address Mapping
 
 When generating location-based data, Smock-it intelligently associates countries with their respective states and cities, ensuring the data is both logical and realistic.
 
-### 3\. Text & Number Generation
+### 3. Text & Number Generation
 
 Using advanced, context-aware algorithms, it generates realistic names, industries, emails, currencies, and other text-based data. This ensures that your test data closely mirrors real-world scenarios, enhancing its authenticity and reliability.
 
-### 4\. Upload Generated Data to Multiple Orgs
+### 4. Upload Generated Data to Multiple Orgs
 
 The new data upload feature allows users to upload generated datasets to different orgs using the username or alias. This makes it seamless for teams to test across environments with the exact same dataset.
 
@@ -39,15 +38,15 @@ The new data upload feature allows users to upload generated datasets to differe
 
 Smock-it removes the biggest roadblocks Salesforce professionals face when managing and generating test data. 
 
-### 1\. Reuse Data Across Multiple Orgs
+### 1. Reuse Data Across Multiple Orgs
 
 Smock-It lets you easily upload and reuse generated data across different orgs, making it seamless for teams to test with the same dataset. This ensures consistency and accuracy across environments.
 
-### 2\. Realistic data generation
+### 2. Realistic data generation
 
 QAs need test data that looks realistic, and Smock-It delivers just that. The data it generates isn’t just random numbers or text; it’s context-aware, logically correct, and closely resembles real-world scenarios. This ensures that the data is not only realistic but also meaningful.
 
-### 3\. Data Generation Speed & Usage Limit
+### 3. Data Generation Speed & Usage Limit
 
 With no API dependencies, data generation time has drastically reduced, from approximately 15 minutes for 200,000 records to just 2 minutes. It also removes previous limitations, allowing unlimited data generation per day.
 
@@ -140,77 +139,67 @@ Smock-it generates output based on the format provided in the template configura
 
 ## Smock-it Commands 
 
-#### 1\. Create Template 
+> **📌 Important Migration Notice**  
+> All `sf template` and `sf data` commands are being deprecated in favor of the new `sf smockit` namespace.  
+> See the [Legacy Command Migration](#legacy-command-migration) section below for a complete mapping.
+
+#### 1. Create Template 
 
 Create fresh template for data generation. [Read more](https://github.com/concretios/smock-it/wiki/Template-Init-Command)
 
-``` 
-⚠️ Warning: The template create command 'sf template init [--default]' will be deprecated soon. Use
-
+```bash
 sf smockit template init [--default]
 ```
 
-#### 2\. Validate Template
+#### 2. Validate Template
 
 Check data generation template for correctness. [Read more](https://github.com/concretios/smock-it/wiki/Template-Validate-Command)
 
-``` 
-⚠️ Warning: The template validate command 'sf template validate' will be deprecated soon. Use
-
+```bash
 sf smockit template validate -t <templateFileName> -a <aliasorUsername>
 ```
 
-#### 3\. Generate Data
+#### 3. Generate Data
 
 Generate and/or insert data based on the objects and settings defined within the template. [Read more](https://github.com/concretios/smock-it/wiki/Data-Generate-Command)
 
-``` 
-⚠️ Warning: The template generate command 'sf template generate' will be deprecated soon. Use
-
+```bash
 sf smockit data generate -t <templateFileName> -a <aliasorUsername>
 ```
 
 **Note:** The alias name or username of the Salesforce Org is required.
 
-#### 4\. Data Upload
+#### 4. Data Upload
 
 Upload generated data (CSV, JSON) to multiple orgs. [Read more](https://github.com/concretios/smock-it/wiki/Data-Upload-Command)
 
-``` 
-⚠️ Warning: The template upload command 'sf data upload' will be deprecated soon. Use
-
+```bash
 sf smockit data upload -u <filename.json|filename.csv> -a <alias_or_username> -s <sObject>
 ```
 
 **Note**: Make sure to append the filename with .json or .csv to upload the data.
 
-#### 5\. Print Template
+#### 5. Print Template
 
 Review the template configuration before using it to generate data in read-only. [Read more](https://github.com/concretios/smock-it/wiki/Template-Print-Command)
 
-``` 
-⚠️ Warning: The template print command 'sf template print' will be deprecated soon. Use
-
+```bash
 sf smockit template print -t <templateFileName>
 ```
 
-#### 6\. Upsert Configurations
+#### 6. Upsert Configurations
 
 Modify or add configuration to an existing template. [Read more](https://github.com/concretios/smock-it/wiki/Template-Upsert-Command)
 
-``` 
-⚠️ Warning: The template upsert command 'sf template upsert' will be deprecated soon. Use
-
+```bash
 sf smockit template upsert -t <templateFileName> [-s <sObject>] [-c <recordCount>] [-x <namespaceToExclude>] [-f <outputFormat>] [-e <fieldsToExclude>] [-i <fieldsToConsider>] [-p <pickLeftFields>]
 ```
 
-#### 7\. Remove Configurations
+#### 7. Remove Configurations
 
 Remove specific configurations from an existing data generation template. [Read more](https://github.com/concretios/smock-it/wiki/Template-Remove-Command)
 
-``` 
-⚠️ Warning: The template remove command 'sf template remove' will be deprecated soon. Use
-
+```bash
 sf smockit template remove -t <templateFileName> [-s <sObject>] [-c <recordCount>] [-x <namespaceToExclude>] [-f <outputFormat>] [-e <fieldsToExclude>] [-i <fieldsToConsider>] [-p <pickLeftFields>]
 ```
 
@@ -230,6 +219,21 @@ sf smockit template remove -t <templateFileName> [-s <sObject>] [-c <recordCount
 | `--pickLeftFields` | `-p` | Pick Left Fields | If true, generates data for all fields except those listed in `FieldsToExclude`. If false, generates data only for the fields specified in `FieldsToConsider`. |
 | `--aliasOrUserName` | `-a` | Alias Or UserName | This flag is required when using the validate and data generate commands. It accepts a username or alias name and only supports orgs listed in the Salesforce Org List. |
 
+## Legacy Command Migration
+
+> **⚠️ Deprecated Commands**  
+> The following commands are deprecated and will be removed in a future version. Please update your scripts to use the new `sf smockit` commands.
+
+| Legacy Command | New Command | Remarks |
+| ----- | ----- | ----- |
+| `sf template init [--default]` | `sf smockit template init [--default]` | Template creation command moved to smockit namespace |
+| `sf template validate -t <templateFileName> -a <aliasorUsername>` | `sf smockit template validate -t <templateFileName> -a <aliasorUsername>` | Template validation command moved to smockit namespace |
+| `sf template generate -t <templateFileName> -a <aliasorUsername>` | `sf smockit data generate -t <templateFileName> -a <aliasorUsername>` | Command moved to smockit namespace and reorganized under `data` subcommand |
+| `sf data upload -u <filename> -a <alias_or_username> -s <sObject>` | `sf smockit data upload -u <filename> -a <alias_or_username> -s <sObject>` | Data upload command moved to smockit namespace |
+| `sf template print -t <templateFileName>` | `sf smockit template print -t <templateFileName>` | Template print command moved to smockit namespace |
+| `sf template upsert -t <templateFileName> [options]` | `sf smockit template upsert -t <templateFileName> [options]` | Template upsert command moved to smockit namespace |
+| `sf template remove -t <templateFileName> [options]` | `sf smockit template remove -t <templateFileName> [options]` | Template remove command moved to smockit namespace |
+
 ## Smock-it GitHub Action
 
 Integrate Smock-it within the DevOps pipeline. [Read more](https://github.com/concretios/smock-it/wiki/Smock%E2%80%90It-GitHub-Action)
@@ -240,5 +244,3 @@ To access command help:
  
 ``` 
 sf <template/data> <command> --help
-```
-

--- a/README.md
+++ b/README.md
@@ -224,13 +224,13 @@ sf smockit template remove -t <templateFileName> [-s <sObject>] [-c <recordCount
 > **⚠️ Deprecated Commands**  
 > The following commands are deprecated and will be removed in a future version. Please update your scripts to use the new `sf smockit` commands.
 
-| Legacy Command | New Command | 
-| ----- | ----- | ----- |
-| `sf template init` | `sf smockit template init` | 
-| `sf template validate` | `sf smockit template validate` | 
-| `sf template generate` | `sf smockit data generate` | 
+| Legacy Command | New Command |
+| :------------ | :---------- |
+| `sf template init` | `sf smockit template init` |
+| `sf template validate` | `sf smockit template validate` |
+| `sf template generate` | `sf smockit data generate` |
 | `sf data upload` | `sf smockit data upload` |
-| `sf template print` | `sf smockit template print` | 
+| `sf template print` | `sf smockit template print` |
 | `sf template upsert` | `sf smockit template upsert` |
 | `sf template remove` | `sf smockit template remove` |
 

--- a/README.md
+++ b/README.md
@@ -224,15 +224,15 @@ sf smockit template remove -t <templateFileName> [-s <sObject>] [-c <recordCount
 > **⚠️ Deprecated Commands**  
 > The following commands are deprecated and will be removed in a future version. Please update your scripts to use the new `sf smockit` commands.
 
-| Legacy Command | New Command | Remarks |
+| Legacy Command | New Command | 
 | ----- | ----- | ----- |
-| `sf template init [--default]` | `sf smockit template init [--default]` | Template creation command moved to smockit namespace |
-| `sf template validate -t <templateFileName> -a <aliasorUsername>` | `sf smockit template validate -t <templateFileName> -a <aliasorUsername>` | Template validation command moved to smockit namespace |
-| `sf template generate -t <templateFileName> -a <aliasorUsername>` | `sf smockit data generate -t <templateFileName> -a <aliasorUsername>` | Command moved to smockit namespace and reorganized under `data` subcommand |
-| `sf data upload -u <filename> -a <alias_or_username> -s <sObject>` | `sf smockit data upload -u <filename> -a <alias_or_username> -s <sObject>` | Data upload command moved to smockit namespace |
-| `sf template print -t <templateFileName>` | `sf smockit template print -t <templateFileName>` | Template print command moved to smockit namespace |
-| `sf template upsert -t <templateFileName> [options]` | `sf smockit template upsert -t <templateFileName> [options]` | Template upsert command moved to smockit namespace |
-| `sf template remove -t <templateFileName> [options]` | `sf smockit template remove -t <templateFileName> [options]` | Template remove command moved to smockit namespace |
+| `sf template init` | `sf smockit template init` | 
+| `sf template validate` | `sf smockit template validate` | 
+| `sf template generate` | `sf smockit data generate` | 
+| `sf data upload` | `sf smockit data upload` |
+| `sf template print` | `sf smockit template print` | 
+| `sf template upsert` | `sf smockit template upsert` |
+| `sf template remove` | `sf smockit template remove` |
 
 ## Smock-it GitHub Action
 


### PR DESCRIPTION
- Clean up the readme command line section for easy readability.
- Added new legacy command section that display mapping of old and new commands'.